### PR TITLE
fix decode raw packet flow record header size

### DIFF
--- a/flow_record.go
+++ b/flow_record.go
@@ -70,13 +70,17 @@ func (f ExtendedSwitchFlowRecord) RecordType() int {
 	return TypeExtendedSwitchFlow
 }
 
-func decodeRawPacketFlowRecord(r io.Reader) RawPacketFlowRecord {
+func decodeRawPacketFlowRecord(r io.Reader, dataLength uint32) RawPacketFlowRecord {
 	f := RawPacketFlowRecord{}
 	binary.Read(r, binary.BigEndian, &f.Protocol)
 	binary.Read(r, binary.BigEndian, &f.FrameLength)
 	binary.Read(r, binary.BigEndian, &f.Stripped)
 	binary.Read(r, binary.BigEndian, &f.HeaderSize)
-	f.Header = make([]byte, f.HeaderSize)
+
+	n := f.HeaderSize + 16
+	s := dataLength - n
+	f.Header = make([]byte, f.HeaderSize + s)
+
 	io.ReadFull(r, f.Header)
 	return f
 }

--- a/flow_sample.go
+++ b/flow_sample.go
@@ -133,7 +133,7 @@ func decodeFlowSample(r io.ReadSeeker) Sample {
 		binary.Read(r, binary.BigEndian, &fRH)
 		switch fRH.DataFormat {
 		case TypeRawPacketFlow:
-			sample.Records = append(sample.Records, decodeRawPacketFlowRecord(r))
+			sample.Records = append(sample.Records, decodeRawPacketFlowRecord(r, fRH.DataLength))
 		case TypeEthernetFrameFlow:
 			sample.Records = append(sample.Records, decodeEthernetFrameFlowRecord(r))
 		case TypeIpv4Flow:
@@ -164,7 +164,7 @@ func decodeExpandedFlowSample(r io.ReadSeeker) Sample {
 
 		switch fRH.DataFormat {
 		case TypeRawPacketFlow:
-			sample.Records = append(sample.Records, decodeRawPacketFlowRecord(r))
+			sample.Records = append(sample.Records, decodeRawPacketFlowRecord(r, fRH.DataLength))
 		case TypeEthernetFrameFlow:
 			sample.Records = append(sample.Records, decodeEthernetFrameFlowRecord(r))
 		case TypeIpv4Flow:


### PR DESCRIPTION
I tested the library and some raw packets lose, I search the problem and I see the header size doesnt correct sometimes, I create this fix and solve the problem but I dont know what the exact problem. May be you can solve.
